### PR TITLE
Refactored api_queries.py

### DIFF
--- a/api_queries.py
+++ b/api_queries.py
@@ -172,8 +172,12 @@ def paper_formatter(paper):
 
     authors = []
     try:
-        authors = [author_formatter(paper_author.author)
-                   for paper_author in paper.authors]
+        for paper_author in paper.authors:
+            authors.append({
+                **author_formatter(paper_author.author),
+                'authorNo': paper_author.author_no
+            })
+        authors.sort(key=lambda author: author['authorNo'])
     except (TypeError, AttributeError):
         pass
 

--- a/api_queries.py
+++ b/api_queries.py
@@ -99,6 +99,7 @@ def get_authors_list():
 
 
 authors_list_backend, authors_list_frontend = get_authors_list()
+authors_tuple_frontend = tuple(authors_list_frontend)
 
 
 def author_formatter(author, department: bool = False,
@@ -261,7 +262,8 @@ def get_author_papers(id_frontend: str):
             .join((Author, Paper_Author.author)) \
             .filter(Author.id == id_) \
             .all()
-        response = [paper_formatter(p) for p in papers]  # possible TypeError
+        # possible TypeError
+        response = tuple(paper_formatter(p) for p in papers)
     except (KeyError, TypeError):
         pass
 
@@ -285,7 +287,8 @@ def get_author_papers_year(id_frontend: str, year: int):
             .join((Author, Paper_Author.author)) \
             .filter(Author.id == id_, extract('year', Paper.date) == year) \
             .all()
-        response = [paper_formatter(p) for p in papers]  # possible TypeError
+        # possible TypeError
+        response = tuple(paper_formatter(p) for p in papers)
     except (KeyError, TypeError):
         pass
 
@@ -315,8 +318,9 @@ def get_author_papers_keyword(id_frontend: str, keyword: str):
             .join((Keyword, Paper.keywords)) \
             .filter(Author.id == id_, Keyword.keyword == keyword) \
             .all()
-        response = [paper_formatter(p) for p in papers]
-    except (KeyError, AttributeError, ValueError):
+        # possible TypeError
+        response = tuple(paper_formatter(p) for p in papers)
+    except (KeyError, AttributeError, ValueError, TypeError):
         pass
 
     return response
@@ -349,9 +353,9 @@ def get_author_papers_q(id_frontend: str, q: str):
                 Source_Metric.value <= top_percentile
             ) \
             .all()
-
-        response = [paper_formatter(p) for p in papers]
-    except KeyError:
+        # possible TypeError
+        response = tuple(paper_formatter(p) for p in papers)
+    except (KeyError, TypeError):
         pass
 
     return response
@@ -382,7 +386,7 @@ def get_author_papers_co_id(id_frontend: str, co_id: str):
             .all()
 
         joint_papers = get_joint_papers(papers, co_author, format_results=True)
-        response = joint_papers
+        response = tuple(joint_papers)
     except (KeyError, ValueError, TypeError, AttributeError):
         pass
 
@@ -437,7 +441,6 @@ def get_author_qs(id_frontend: str):
             {'name': 'q3', 'percentiles': []},
             {'name': 'q4', 'percentiles': []},
         ]
-
         for i in author.get_metrics():  # possible AttributeError
             quartile = (100 - i[0] - 1) // 25 + 1
             metrics[quartile-1]['percentiles'].append({
@@ -445,7 +448,7 @@ def get_author_qs(id_frontend: str):
                 'value': i[1]
             })
 
-        response = metrics
+        response = tuple(metrics)
     except (KeyError, AttributeError):
         pass
 
@@ -510,7 +513,7 @@ def get_author_network(id_frontend: str):
         for co, network in co_network.items():
             final_network.extend(network_formatter(co, network))
 
-        response = final_network
+        response = tuple(final_network)
     except (KeyError, AttributeError):
         pass
 

--- a/api_queries.py
+++ b/api_queries.py
@@ -62,6 +62,8 @@ p = session.query(Paper)
 # ==============================================================================
 
 
+initial_response = {'message': 'not found', 'code': 404}
+
 home_institution = i \
     .filter(Institution.id_scp == home_institution_id_scp) \
     .first()
@@ -228,7 +230,7 @@ def get_joint_papers(papers: list, co_author, format_results: bool = False):
 
 
 def get_author(id_frontend: str):
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
     try:
         id_ = authors_list_backend[id_frontend]  # possible KeyError
         author = a.get(id_)  # returns None if not found
@@ -246,7 +248,7 @@ def get_author(id_frontend: str):
 
 def get_author_papers(id_frontend: str):
     # returns a list of all papers for the author 'id_frontend'
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
 
     try:
         id_ = authors_list_backend[id_frontend]  # possible KeyError
@@ -264,7 +266,7 @@ def get_author_papers(id_frontend: str):
 
 def get_author_papers_year(id_frontend: str, year: int):
     # returns a list of papers published in 'year' for the author 'id_frontend'
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
 
     # simple checks on incoming requests
     if not(isinstance(year, int)):
@@ -288,7 +290,7 @@ def get_author_papers_year(id_frontend: str, year: int):
 
 def get_author_papers_keyword(id_frontend: str, keyword: str):
     # returns a list of papers containing 'keyword' for the author 'id_frontend'
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
     if not(isinstance(keyword, str)):  # a simple check on incoming requests
         return response
 
@@ -318,7 +320,7 @@ def get_author_papers_keyword(id_frontend: str, keyword: str):
 
 def get_author_papers_q(id_frontend: str, q: str):
     # returns a list of papers published in a 'q' journal of author 'id_frontend'
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
     # simple checks on incoming requests
     if not(isinstance(q, str)):
         return response
@@ -353,7 +355,7 @@ def get_author_papers_q(id_frontend: str, q: str):
 
 def get_author_papers_co_id(id_frontend: str, co_id: str):
     # returns joint papers between author 'id_frontend' and co_author co_id
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
 
     # simple checks on incoming requests
     if not(isinstance(co_id, str)):
@@ -384,7 +386,7 @@ def get_author_papers_co_id(id_frontend: str, co_id: str):
 
 
 def get_author_trend(id_frontend: str):
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
     try:
         id_ = authors_list_backend[id_frontend]  # possible KeyError
         author = a.get(id_)  # None if not found
@@ -405,7 +407,7 @@ def get_author_trend(id_frontend: str):
 
 
 def get_author_keywords(id_frontend: str):
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
 
     try:
         id_ = authors_list_backend[id_frontend]  # possible KeyError
@@ -420,7 +422,7 @@ def get_author_keywords(id_frontend: str):
 
 
 def get_author_qs(id_frontend: str):
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
 
     try:
         id_ = authors_list_backend[id_frontend]  # possible KeyError
@@ -447,7 +449,7 @@ def get_author_qs(id_frontend: str):
 
 
 def get_author_network(id_frontend: str):
-    response = {'message': 'not found', 'code': 404}  # initial response
+    response = initial_response
     final_network = []
 
     try:

--- a/api_queries.py
+++ b/api_queries.py
@@ -337,10 +337,8 @@ def get_author_keywords(id_frontend: str, keyword: str = ''):
                     papers = [paper_formatter(p) for p in papers]
                     response = papers
                 else:
-                    keywords = author.get_keywords(
+                    response = author.get_keywords(
                         threshold=keywords_threshold)
-                    response = {k.keyword: v for k, v in keywords.items()}
-
             except (AttributeError):
                 pass
     except KeyError:

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 
 from api_queries import \
     initial_response, \
-    authors_list_frontend, \
+    authors_tuple_frontend, \
     get_author, \
     get_author_papers, \
     get_author_papers_year, \
@@ -31,7 +31,7 @@ async def home():
 
 @app.get('/a/list')
 async def show_authors_list():
-    return authors_list_frontend
+    return authors_tuple_frontend
 
 
 @app.get('/a/{id_frontend}')

--- a/main.py
+++ b/main.py
@@ -1,16 +1,32 @@
 import uvicorn
 from fastapi import FastAPI
 
-from api_queries import authors_list_frontend, get_author, get_author_papers, \
-    get_author_trend, get_author_keywords, get_author_journals, \
-    get_author_network, get_joint_papers_id
+from api_queries import \
+    initial_response, \
+    authors_list_frontend, \
+    get_author, \
+    get_author_papers, \
+    get_author_papers_year, \
+    get_author_papers_keyword, \
+    get_author_papers_q, \
+    get_author_papers_co_id, \
+    get_author_trend, \
+    get_author_keywords, \
+    get_author_qs, \
+    get_author_network
+
 
 app = FastAPI()
 
 
 @app.get('/')
 async def home():
-    return {'key': 'Visit list', 'url': 'http://127.0.0.1:8000/a/list'}
+    return initial_response
+
+
+@app.get('/a')
+async def home():
+    return initial_response
 
 
 @app.get('/a/list')
@@ -20,47 +36,44 @@ async def show_authors_list():
 
 @app.get('/a/{id_frontend}')
 async def show_author(id_frontend: str):
-    response = get_author(id_frontend)
-    return response
+    return get_author(id_frontend)
 
 
 @app.get('/a/{id_frontend}/papers')
-async def show_author(id_frontend: str, year: int = None, coID: str = None,
-                      tag: str = None, q: str = None):
-    response = get_author_papers(id_frontend)
-    return response
+async def show_author(id_frontend: str, year: int = None, keyword: str = None,
+                      q: str = None, coID: str = None,):
+    params_set = {year, keyword, q, coID}
+    if len(params_set) > 2:  # more than 1 parameter in the request
+        return initial_response
+    if year:
+        return get_author_papers_year(id_frontend, year=year)
+    if keyword:
+        return get_author_papers_keyword(id_frontend, keyword=keyword)
+    if q:
+        return get_author_papers_q(id_frontend, q=q)
+    if coID:
+        return get_author_papers_co_id(id_frontend, co_id=coID)
+    return get_author_papers(id_frontend)
 
 
 @app.get('/a/{id_frontend}/trend')
-async def show_author(id_frontend: str, year: int = None):
-    response = get_author_trend(id_frontend)
-    if year:
-        response = get_author_papers(id_frontend, year)
-    return response
-
-
-@app.get('/a/{id_frontend}/network')
-async def show_author(id_frontend: str, coID: str = None):
-    response = get_author_network(id_frontend)
-    if coID:
-        response = get_joint_papers_id(id_frontend=id_frontend, co_id=coID)
-    return response
+async def show_author(id_frontend: str):
+    return get_author_trend(id_frontend)
 
 
 @app.get('/a/{id_frontend}/keywords')
-async def show_author(id_frontend: str, tag: str = None):
-    response = get_author_keywords(id_frontend)
-    if tag:
-        response = get_author_keywords(id_frontend, keyword=tag)
-    return response
+async def show_author(id_frontend: str):
+    return get_author_keywords(id_frontend)
 
 
-@app.get('/a/{id_frontend}/journals')
-async def show_author(id_frontend: str, q: str = None):
-    response = get_author_journals(id_frontend)
-    if q:
-        response = get_author_journals(id_frontend, q)
-    return response
+@app.get('/a/{id_frontend}/qs')
+async def show_author(id_frontend: str):
+    return get_author_qs(id_frontend)
+
+
+@app.get('/a/{id_frontend}/network')
+async def show_author(id_frontend: str):
+    return get_author_network(id_frontend)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -14,12 +14,8 @@ async def home():
 
 
 @app.get('/a/list')
-async def show_authors_list(inst_fid: str = None):
-    # response = {'key': 'list of all authors in the db'}
-    response = authors_list_frontend
-    if inst_fid:
-        response = {'key': f'FEATURE !READY: list of all authors in {inst_fid}'}
-    return response
+async def show_authors_list():
+    return authors_list_frontend
 
 
 @app.get('/a/{id_frontend}')
@@ -29,7 +25,8 @@ async def show_author(id_frontend: str):
 
 
 @app.get('/a/{id_frontend}/papers')
-async def show_author(id_frontend: str):
+async def show_author(id_frontend: str, year: int = None, coID: str = None,
+                      tag: str = None, q: str = None):
     response = get_author_papers(id_frontend)
     return response
 


### PR DESCRIPTION
Closes #1 

Some notes:

- **The changes made here are not backward compatible.**
- The front-end should be changed to use the latest updates:
    - All requests that will result in a list of papers have to be made to `/papers` (e.g. `/a/authorID/papers?year=2020`).
    - The returned list of papers contains more info (such as an ordered list of authors pmsoltani/react-dash#9).
    - Requests should contain at most **1** parameter.
    - The `/journals` endpoint is now called `/qs` and it now returns a nested list of percentiles, suitable for a sunburst chart.
    - The `/network` endpoint now sends first names and last names separately (pmsoltani/react-dash#7)
