### PR TITLE
2

### DIFF
--- a/api_queries.py
+++ b/api_queries.py
@@ -75,7 +75,12 @@ def get_authors_list():
     # get a list of all faculty members of the home_institution
     authors = a \
         .with_entities(
-            Author.id, Author.id_frontend, Author.first, Author.last) \
+            Author.id,
+            Author.id_frontend,
+            Author.first,
+            Author.last,
+            Author.first_pref,
+            Author.last_pref) \
         .distinct() \
         .join((Department, Author.departments)) \
         .join((Institution, Department.institution)) \
@@ -92,8 +97,8 @@ def get_authors_list():
 
         response_frontend.append({
             'idFrontend': author.id_frontend,
-            'first': author.first,
-            'last': author.last
+            'first': author.first_pref or author.first,
+            'last': author.last_pref or author.last
         })
     return response_backend, response_frontend
 
@@ -113,8 +118,11 @@ def author_formatter(author, department: bool = False,
             for d in author.departments:  # possible TypeError, AttributeError
                 if d.name == 'Undefined':  # default initial department
                     continue
-                departments.append(
-                    {'name': d.name, 'idFrontend': d.id_frontend})
+                departments.append({
+                    'name': d.name,
+                    'type': d.type,
+                    'idFrontend': d.id_frontend
+                })
             result['departments'] = departments
         except (TypeError, AttributeError):
             pass
@@ -144,12 +152,8 @@ def author_formatter(author, department: bool = False,
 
     return {
         'idFrontend': author.id_frontend,
-        'first': author.first,
-        'last': author.last,
-        # 'first_fa': author.first_fa,
-        # 'last_fa': author.last_fa,
-        # 'first_pref': author.first_pref,
-        # 'last_pref': author.last_pref,
+        'first': author.first_pref or author.first,
+        'last': author.last_pref or author.last,
         'sex': author.sex,
         'type': author.type,
         'rank': author.rank,
@@ -202,17 +206,13 @@ def network_formatter(from_, to_dict: dict):
     for k, v in to_dict.items():
         result.append({
             'from': {
-                'first': from_.first,
-                'last': from_.last,
-                # 'first_pref': from_.first_pref,
-                # 'last_pref': from_.last_pref,
+                'first': from_.first_pref or from_.first,
+                'last': from_.last_pref or from_.last,
                 'idFrontend': from_.id_frontend,
             },
             'to': {
-                'first': k.first,
-                'last': k.last,
-                # 'first_pref': k.first_pref,
-                # 'last_pref': k.last_pref,
+                'first': k.first_pref or k.first,
+                'last': k.last_pref or k.last,
                 'idFrontend': k.id_frontend
             },
             'value': v,
@@ -238,9 +238,7 @@ def get_author(id_frontend: str):
     response = initial_response
     try:
         id_ = authors_list_backend[id_frontend]  # possible KeyError
-        author = a.get(id_)  # returns None if not found
-        departments = []
-        profiles = []
+        author = a.get(id_)  # None if not found
         if author:
             response = author_formatter(
                 author, department=True, profile=True, institution=True,
@@ -521,4 +519,4 @@ def get_author_network(id_frontend: str):
 
 
 if __name__ == "__main__":
-    print()
+    pass

--- a/elsametric/helpers/process.py
+++ b/elsametric/helpers/process.py
@@ -1046,8 +1046,10 @@ def ext_faculty_process(session, file_path: str, dept_file_path: str,
         3. finds the faculty members of the institution based on their
         Scopus ID
         4. for each faculty:
-            a. adds his/her details (sex, department, rank)
-            b. adds his/her profiles (email, office phone, website)
+            a. adds his/her details (preferred name, sex, department,
+            rank)
+            b. adds his/her profiles (email, office phone, website,
+            institutional id)
             c. adds his/her already created department(s) or create them
             d. unlinks the 'Undefined' department from him/her
         5. adds the updated Author objects to a list and return it
@@ -1107,6 +1109,15 @@ def ext_faculty_process(session, file_path: str, dept_file_path: str,
             continue
 
         # adding faculty details
+        faculty.first_pref = key_get(row, keys, 'First En') or \
+            faculty.first_pref
+        faculty.middle_pref = key_get(row, keys, 'Middle En') or \
+            faculty.middle_pref
+        faculty.last_pref = key_get(row, keys, 'Last En') or faculty.last_pref
+        faculty.initials_pref = key_get(row, keys, 'Initials En') or \
+            faculty.initials_pref
+        faculty.first_fa = key_get(row, keys, 'First Fa')
+        faculty.last_fa = key_get(row, keys, 'Last Fa')
         sex = key_get(row, keys, 'Sex')
         if sex in ['M', 'F']:
             faculty.sex = sex.lower()
@@ -1123,9 +1134,14 @@ def ext_faculty_process(session, file_path: str, dept_file_path: str,
         if row['Office']:
             faculty.profiles.append(
                 Author_Profile(address=row['Office'], type='Phone (Office)'))
-        if row['Page']:
+        if row['Personal Website']:
             faculty.profiles.append(
-                Author_Profile(address=row['Page'], type='Personal Website'))
+                Author_Profile(
+                    address=row['Personal Website'], type='Personal Website'))
+        if row['Institution ID']:
+            faculty.profiles.append(
+                Author_Profile(
+                    address=row['Institution ID'], type='Institution ID'))
 
         # adding the departments that the faculty belongs to
         for dept in row['Departments'].split(','):

--- a/elsametric/models/author.py
+++ b/elsametric/models/author.py
@@ -20,6 +20,10 @@ class Author(Base):
     middle = Column(VARCHAR(45), nullable=True)
     last = Column(VARCHAR(45), nullable=True)
     initials = Column(VARCHAR(45), nullable=True)
+    first_pref = Column(VARCHAR(45), nullable=True)
+    middle_pref = Column(VARCHAR(45), nullable=True)
+    last_pref = Column(VARCHAR(45), nullable=True)
+    initials_pref = Column(VARCHAR(45), nullable=True)
     first_fa = Column(VARCHAR(45), nullable=True)
     last_fa = Column(VARCHAR(45), nullable=True)
     sex = Column(
@@ -54,6 +58,10 @@ class Author(Base):
         self.middle = middle
         self.last = last
         self.initials = initials
+        self.first_pref = first
+        self.middle_pref = middle
+        self.last_pref = last
+        self.initials_pref = initials
         self.sex = sex
         self.type = type
         self.rank = rank

--- a/elsametric/models/author_profile.py
+++ b/elsametric/models/author_profile.py
@@ -16,7 +16,7 @@ class Author_Profile(Base):
         INTEGER(unsigned=True),
         ForeignKey('author.id'), primary_key=True, nullable=False
     )
-    address = Column(VARCHAR(256), nullable=False)
+    address = Column(VARCHAR(256), nullable=False, unique=True)
     type = Column(VARCHAR(45), nullable=False)
 
     # Relationships


### PR DESCRIPTION
Closes #2 

Notes:

- The branch `2` was first accidentally merged into `master`. The merge was subsequently reverted (#11). It is now being merged into `dev` as originally intended.
- Here is a summary of the changes made to the SQLAlchemy model and the API structure:
    - The `Author_Profile` class has now a `unique` constraint on the `address` columns. Care must be taken when introducing a third-party source file, as it should not contain any duplicated profile addresses.
    - The `ext_faculty_process` function now uses the third-party names to update the "preferred names" of the authors when possible.
    - The `ext_faculty_process` function now adds `Institution ID` as a new profile address.
    - The API now returns the new "preferred names" when possible.
    - The API now returns the `type` of the author's department, along with its `name`.